### PR TITLE
Read chat log in interval - closes #26

### DIFF
--- a/src/components/electron/Filestream.js
+++ b/src/components/electron/Filestream.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import getLastLine from '../../utils/getLastLine'
-
-const fs = window.require('fs')
+import { keys } from '../../utils/keys'
 
 class Filestream extends React.Component {
   constructor(props) {
@@ -11,20 +10,20 @@ class Filestream extends React.Component {
     }
   }
 
+  intervalFunc(file) {
+    getLastLine(file, 1)
+      .then(lastLine => {
+        this.props.onLogUpdate(lastLine)
+        this.setState({ original: lastLine })
+      })
+      .catch(err => {
+        console.error(err)
+      })
+  }
   componentWillReceiveProps(nextProps) {
-    fs.watch(nextProps.file[0], (event, filename) => {
-      if (filename) {
-        getLastLine(nextProps.file[0], 1)
-          .then(lastLine => {
-            this.props.onLogUpdate(lastLine)
-            this.setState({ original: lastLine })
-          })
-          .catch(err => {
-            console.error(err)
-          })
-      } else {
-      }
-    })
+    clearInterval(this.intervalFunc)
+
+    setInterval(this.intervalFunc(nextProps.file[0]), keys.POLLING_INTERVAL)
   }
 
   render() {


### PR DESCRIPTION
I had to stop using fs.watch as PoE actually doesn't save Client.txt - it just streams to it and saves on game close, so my code would never pick up any changes.

My shitty interim solution is to poll the file every x milliseconds (configurable in config) and get the last line. 

This is super processor and memory intensive (tested with 200 MB chat log) so I need to optimize this at some point - opened #27