### PR TITLE
Fix user messaging for loading/saving the Client.txt - closes #7

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -55,7 +55,7 @@ ipcMain.on(FETCH_FILEPATH_FROM_STORAGE, () => {
         if (data.path) {
           win.send(HANDLE_FETCH_FILEPATH_FROM_STORAGE, {
             success: true,
-            message: 'loaded path, it is: ',
+            message: 'reading from settings: ',
             path: data.path
           })
         }
@@ -63,7 +63,7 @@ ipcMain.on(FETCH_FILEPATH_FROM_STORAGE, () => {
     } else {
       win.send(HANDLE_FETCH_FILEPATH_FROM_STORAGE, {
         success: false,
-        message: 'nothing saved yet'
+        message: 'Please select a log file.'
       })
     }
   })
@@ -80,7 +80,7 @@ ipcMain.on(SAVE_FILEPATH_TO_STORAGE, (event, arg) => {
     }
     win.send(HANDLE_SAVE_FILEPATH_TO_STORAGE, {
       success: true,
-      message: 'saved path is: ',
+      message: 'saved to settings: ',
       path: arg
     })
   })

--- a/src/App.js
+++ b/src/App.js
@@ -9,7 +9,8 @@ import {
   SAVE_FILEPATH_TO_STORAGE,
   HANDLE_SAVE_FILEPATH_TO_STORAGE,
   FETCH_FILEPATH_FROM_STORAGE,
-  HANDLE_FETCH_FILEPATH_FROM_STORAGE
+  HANDLE_FETCH_FILEPATH_FROM_STORAGE,
+  DEFAULT_PICK_FILE_MESSAGE
 } from './utils/constants'
 
 const { ipcRenderer } = window.require('electron')
@@ -21,8 +22,7 @@ class App extends Component {
       file: null,
       original: '',
       fileSaveSuccess: false,
-      fileSaveMessage: '',
-      fileSavePath: ''
+      fileSaveMessage: ''
     }
 
     this.handleFileChange = this.handleFileChange.bind(this)
@@ -55,16 +55,17 @@ class App extends Component {
   handleFilepathFetch(event, data) {
     const { success, message, path } = data
     if (success) {
-      this.setState({ fileSavePath: path })
-      this.handleFileChange(path)
+      this.setState({ fileSaveMessage: message, file: path })
     } else {
-      console.log(message)
+      this.setState({
+        fileSaveMessage: message + DEFAULT_PICK_FILE_MESSAGE
+      })
     }
   }
 
   handleFilepathSaved(event, data) {
     const { path, message } = data
-    this.setState({ fileSaveMessage: message, fileSavePath: path })
+    this.setState({ fileSaveMessage: message, file: path })
   }
 
   handleFileChange(file) {
@@ -77,17 +78,14 @@ class App extends Component {
   }
 
   render() {
-    const { fileSaveMessage, fileSavePath } = this.state
+    const { fileSaveMessage, file } = this.state
     return (
       <div className="App">
         <header className="App-header">
-          <Picker onFileChange={this.handleFileChange} />
           <p>
-            {fileSaveMessage}: {fileSavePath}
+            {fileSaveMessage} {file}
           </p>
-          <button onClick={this.loadApplicationJson}>
-            Try to load me from application.json
-          </button>
+          <Picker onFileChange={this.handleFileChange} />
           <Filestream
             file={this.state.file}
             onLogUpdate={this.handleLogUpdate}

--- a/src/components/electron/Picker.js
+++ b/src/components/electron/Picker.js
@@ -5,9 +5,6 @@ const { dialog } = window.require('electron').remote
 class Picker extends React.Component {
   constructor(props) {
     super(props)
-    this.state = {
-      selectedFile: 'no file selected'
-    }
 
     this.handleClick = this.handleClick.bind(this)
   }
@@ -20,7 +17,6 @@ class Picker extends React.Component {
       file => {
         if (file !== undefined) {
           this.props.onFileChange(file)
-          this.setState({ selectedFile: file })
         }
       }
     )
@@ -29,8 +25,7 @@ class Picker extends React.Component {
   render() {
     return (
       <div>
-        <p>File: {this.state.selectedFile}</p>
-        <button onClick={this.handleClick}>Select text file</button>
+        <button onClick={this.handleClick}>Select Client.txt location</button>
       </div>
     )
   }

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -3,5 +3,7 @@ module.exports = {
   SAVE_FILEPATH_TO_STORAGE: 'save-filepath-to-storage',
   HANDLE_FETCH_FILEPATH_FROM_STORAGE: 'handle-fetch-filepath-from-storage',
   HANDLE_SAVE_FILEPATH_TO_STORAGE: 'handle-save-filepath-to-storage',
-  POLLING_INTERVAL: 1000
+  POLLING_INTERVAL: 1000,
+  DEFAULT_PICK_FILE_MESSAGE:
+    ' - It is usually located in C:\\Program Files (x86)\\Grinding Gear Games\\Path of Exile\\logs\\Client.txt'
 }


### PR DESCRIPTION
I solved that one differently. The picker will always be there. But if a file was never selected (no application.json exists) the app will ask you to select a Client.txt and give you some hint where to find it.

Once you picked a file, it'll say "saved in settings: PATH"

If you close and open the app again, it'll say "loaded from settings: PATH"

... and you can always access the picker if (for some reason) you want to select a different file.

... will probably style that later to make it a bit nicer...